### PR TITLE
Working version, reverted Character class declaration in /lib/deps.ts

### DIFF
--- a/lib/deps.ts
+++ b/lib/deps.ts
@@ -45,7 +45,6 @@ export class ListedEpisode {
     }
 }
 
-import { section, tableOfContents } from './characters.ts';
 /**
  * Character appearance
  */
@@ -60,12 +59,14 @@ export class Character {
         this.role = role;
     }
 
-    async tableContents() {
-        return await tableOfContents(this);
+    async tableofContents() {
+        const characters = await import('./characters.ts');
+    return await characters.tableOfContents(this);
     }
 
     async articleSection(id: string) {
-        return await section(this, id);
+        const characters = await import('./characters.ts');
+        return await characters.section(this, id)
     }
 }
 


### PR DESCRIPTION
This is a great library but I found one small flaw, ~~someone had corrupted the original wish~~, the version at HEAD is unusable. It fails tests, etc. 
However, older versions _were_ workable, so I looked for what the difference was. I don't know enough about Typescript to really say _why_ the version on the left breaks (and I haven't tested if simply adding an `await` would fix it) but what I do know is that the version on the right works. :) 

It looks like this is unmaintained, but I'm finding it useful for a project and I'm sure others might in the future, so I wanted to at least leave a record of the fix via a pull request.